### PR TITLE
RetryHint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@5bc4b83f25ff4c944cd6253ba189e50d1997ab3c # v4.1.0
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@826aa545bb56f6c7c551d44febb420c0293c8bff # v4.2.0
     with:
       release-type: library
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@826aa545bb56f6c7c551d44febb420c0293c8bff # v4.2.0
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@9e191cedb6f62d364dc8706c07107c8ef612c346 # v4.2.2
     with:
       release-type: library
     secrets: inherit

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4
-	github.com/xmidt-org/urlegit v0.1.0
+	github.com/xmidt-org/urlegit v0.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/xmidt-org/urlegit v0.1.0 h1:WZLlWo0e5JNZabLEi7/1+sK/np9qrH9XnoB+ZdsHieM=
-github.com/xmidt-org/urlegit v0.1.0/go.mod h1:ih/VtgW3xfpV7FNIrHUpNdP0GapcfLOND8y0JwH51vA=
+github.com/xmidt-org/urlegit v0.1.1 h1:sjFlckD7Okql7gQACX5hpicqiqD/kIs1hhG7a623dJQ=
+github.com/xmidt-org/urlegit v0.1.1/go.mod h1:ih/VtgW3xfpV7FNIrHUpNdP0GapcfLOND8y0JwH51vA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/webhook.go
+++ b/webhook.go
@@ -64,6 +64,7 @@ type RegistrationV1 struct {
 }
 type RetryHint struct {
 	//RetryEachUrl is the amount of times a URL should be retried given a failed response until the next URL in the request is tried.
+	//Default value will be set to none
 	RetryEachUrl int `json:"retry_each_url"`
 
 	//MaxRetry is the total amount times a request will be retried.
@@ -201,10 +202,6 @@ type RegistrationV2 struct {
 	// Expires describes the time this subscription expires.
 	// TODO: list of supported formats
 	Expires time.Time `json:"expires"`
-
-	//RetryHint is the substructure for configuration related to retrying requests.
-	// (Optional, if omited then retries will be based on default values defined by server)
-	RetryHint RetryHint `json:"retry_hint"`
 }
 
 type Option interface {

--- a/webhook.go
+++ b/webhook.go
@@ -62,6 +62,13 @@ type RegistrationV1 struct {
 	// Until describes the time this subscription expires.
 	Until time.Time `json:"until"`
 }
+type RetryHint struct {
+	//RetryEachUrl is the amount of times a URL should be retried given a failed response until the next URL in the request is tried.
+	RetryEachUrl int `json:"retry_each_url"`
+
+	//MaxRetry is the total amount times a request will be retried.
+	MaxRetry int `json:"max_retry"`
+}
 
 // Webhook is a substructure with data related to event delivery.
 type Webhook struct {
@@ -105,6 +112,10 @@ type Webhook struct {
 		// srv record attribute `weight` or `priortiy` can be used.
 		LoadBalancingScheme string `json:"load_balancing_scheme"`
 	} `json:"dns_srv_record"`
+
+	//RetryHint is the substructure for configuration related to retrying requests.
+	// (Optional, if omited then retries will be based on default values defined by server)
+	RetryHint RetryHint `json:"retry_hint"`
 }
 
 // Kafka is a substructure with data related to event delivery.
@@ -119,6 +130,10 @@ type Kafka struct {
 	// going to be based on https://pkg.go.dev/github.com/IBM/sarama#Config
 	// this substructures also includes auth related secrets, noted `MaxOpenRequests` will be excluded since it's already exposed
 	KafkaProducer struct{} `json:"kafka_producer"`
+
+	//RetryHint is the substructure for configuration related to retrying requests.
+	// (Optional, if omited then retries will be based on default values defined by server)
+	RetryHint RetryHint `json:"retry_hint"`
 }
 
 // FieldRegex is a substructure with data related to regular expressions.
@@ -186,6 +201,10 @@ type RegistrationV2 struct {
 	// Expires describes the time this subscription expires.
 	// TODO: list of supported formats
 	Expires time.Time `json:"expires"`
+
+	//RetryHint is the substructure for configuration related to retrying requests.
+	// (Optional, if omited then retries will be based on default values defined by server)
+	RetryHint RetryHint `json:"retry_hint"`
 }
 
 type Option interface {


### PR DESCRIPTION
Added a RetryHint struct for Webhook and Kafka as per discussion with John and Wes.

Current Caduceus functionality updates request with the next url after each retry. RetryHint will allow clients to determine if they want to retry a url multiple times before moving on to the next url.