### PR TITLE
updated note part of the Webhook Accept field

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -101,11 +101,11 @@ type Webhook struct {
 	// a 406 response code is returned: application/octet-stream, application/json, application/jsonl, application/msgpack.
 	/*
 		Note:
-			An `Accept` of application/octet-stream supports single message return with payload of WRP
-			An `Accept` of application/json supports single message return with json form of WRP
-			An `Accept` of application/jsonl supports single or multi records with each line being independent json encoding of a WRP
-			An `Accept` of application/msgpack supports single or multi records with a single record being of msgpack and multiple records being
-			returned as an array of binary data with the binary data being the msgpacked WRP for each message
+			application/wrp+json - one json encoded wrp message
+			application/wrp+msgpack - one msgpack encoded wrp message
+			application/wrp+octet-stream - one message with the wrp payload in the http payload
+			application/wrp+jsonl - multiple jsonl encoded wrp messages
+			application/wrp+msgpackl - multiple msgpackl encoded wrp messages
 	*/
 	Accept string `json:"accept"`
 

--- a/webhook.go
+++ b/webhook.go
@@ -99,9 +99,14 @@ type DNSSrvRecord struct {
 type Webhook struct {
 	// Accept is the encoding type of outgoing events. The following encoding types are supported, otherwise
 	// a 406 response code is returned: application/octet-stream, application/json, application/jsonl, application/msgpack.
-	// Note: An `Accept` of application/octet-stream or application/json will result in a single response for batch sizes of 0 or 1
-	// and batch sizes greater than 1 will result in a multipart response. An `Accept` of application/jsonl or application/msgpack
-	// will always result in a single response with a list of batched events for any batch size.
+	/*
+		Note:
+			An `Accept` of application/octet-stream supports single message return with payload of WRP
+			An `Accept` of application/json supports single message return with json form of WRP
+			An `Accept` of application/jsonl supports single or multi records with each line being independent json encoding of a WRP
+			An `Accept` of application/msgpack supports single or multi records with a single record being of msgpack and multiple records being
+			returned as an array of binary data with the binary data being the msgpacked WRP for each message
+	*/
 	Accept string `json:"accept"`
 
 	// AcceptEncoding is the content type of outgoing events. The following content types are supported, otherwise


### PR DESCRIPTION
Discussed with Wes regarding the multipart response for the new `Webhook` struct.

Wes said we should not do multipart response. We updated the `Note` portion of the `Accept` field description. Any feedback/questions/discussions on the note or whether or not to do multipart responses are welcome.