### PR TITLE
Refactor: replace webhook naming scheme with a sink agnostic naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webhook-schema
 
-A simple library for housing the webhook-schema and validation code. 
+A simple library for housing the wrpEventStream-schema and validation code. 
 
 [![Build Status](https://github.com/xmidt-org/webhook-schema/actions/workflows/ci.yml/badge.svg)](https://github.com/xmidt-org/webhook-schema/actions/workflows/ci.yml)
 [![codecov.io](http://codecov.io/github/xmidt-org/webhook-schema/coverage.svg?branch=main)](http://codecov.io/github/xmidt-org/webhook-schema?branch=main)

--- a/customDuration.go
+++ b/customDuration.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package webhook
+package stream
 
 import (
 	"bytes"

--- a/customDuration_test.go
+++ b/customDuration_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package webhook
+package stream
 
 import (
 	"encoding/json"

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package webhook
+package stream
 
 import (
 	"fmt"
@@ -54,10 +54,10 @@ type atLeastOneEventOption struct{}
 
 func (atLeastOneEventOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateOneEvent()
-	case *RegistrationV2:
-		return fmt.Errorf("%w: RegistrationV2 does not have an events field to validate", ErrInvalidType)
+	case *SchemaV2:
+		return fmt.Errorf("%w: SchemaV2 does not have an events field to validate", ErrInvalidType)
 	default:
 		return ErrUknownType
 	}
@@ -76,9 +76,9 @@ type eventRegexMustCompileOption struct{}
 
 func (eventRegexMustCompileOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateEventRegex()
-	case *RegistrationV2:
+	case *SchemaV2:
 		return r.ValidateEventRegex()
 	default:
 		return ErrUknownType
@@ -99,10 +99,10 @@ type deviceIDRegexMustCompileOption struct{}
 
 func (deviceIDRegexMustCompileOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateDeviceId()
-	case *RegistrationV2:
-		return fmt.Errorf("%w: RegistrationV2 does not use DeviceID directly, use `FieldRegex` instead", ErrInvalidType)
+	case *SchemaV2:
+		return fmt.Errorf("%w: SchemaV2 does not use DeviceID directly, use `FieldRegex` instead", ErrInvalidType)
 	default:
 		return ErrUknownType
 	}
@@ -112,32 +112,32 @@ func (deviceIDRegexMustCompileOption) String() string {
 	return "DeviceIDRegexMustCompile()"
 }
 
-// ValidateRegistrationDuration ensures that the requsted registration duration
+// ValidateDuration ensures that the requsted registration duration
 // of a webhook is valid.  This option checks the values set in either the
 // Duration or Until fields of the webhook. If the ttl is less than or equal to
 // zero, this option will not boundary check the registration duration, but will
 // still ensure that the Duration or Until fields are set.
-func ValidateRegistrationDuration(ttl time.Duration) Option {
-	return validateRegistrationDurationOption{ttl: ttl}
+func ValidateDuration(ttl time.Duration) Option {
+	return validateDurationOption{ttl: ttl}
 }
 
-type validateRegistrationDurationOption struct {
+type validateDurationOption struct {
 	ttl time.Duration
 }
 
-func (v validateRegistrationDurationOption) Validate(i any) error {
+func (v validateDurationOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateDuration(v.ttl)
-	case *RegistrationV2:
+	case *SchemaV2:
 		return r.ValidateDuration()
 	default:
 		return ErrUknownType
 	}
 }
 
-func (v validateRegistrationDurationOption) String() string {
-	return "ValidateRegistrationDuration(" + v.ttl.String() + ")"
+func (v validateDurationOption) String() string {
+	return "ValidateDuration(" + v.ttl.String() + ")"
 }
 
 // ProvideTimeNowFunc is an option that allows the caller to provide a function
@@ -152,7 +152,7 @@ type provideTimeNowFuncOption struct {
 
 func (p provideTimeNowFuncOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		r.SetNowFunc(p.nowFunc)
 	}
 
@@ -184,9 +184,9 @@ func (p provideFailureURLValidatorOption) Validate(i any) error {
 	}
 
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		failureURL = r.FailureURL
-	case *RegistrationV2:
+	case *SchemaV2:
 		failureURL = r.FailureURL
 	default:
 		return ErrUknownType
@@ -223,9 +223,9 @@ func (p provideReceiverURLValidatorOption) Validate(i any) error {
 	}
 
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateReceiverURL(p.checker)
-	case *RegistrationV2:
+	case *SchemaV2:
 		return r.ValidateReceiverURL(p.checker)
 	default:
 		return ErrUknownType
@@ -255,10 +255,10 @@ func (p provideAlternativeURLValidatorOption) Validate(i any) error {
 	}
 
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateAltURL(p.checker)
-	case *RegistrationV2:
-		return fmt.Errorf("%w: RegistrationV2 does not have an alternative urls field. Use ProvideReceiverURLValidator() to validate all non-failure urls", ErrInvalidType)
+	case *SchemaV2:
+		return fmt.Errorf("%w: SchemaV2 does not have an alternative urls field. Use ProvideReceiverURLValidator() to validate all non-failure urls", ErrInvalidType)
 	default:
 		return ErrUknownType
 	}
@@ -280,10 +280,10 @@ type noUntilOption struct{}
 
 func (noUntilOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.ValidateNoUntil()
-	case *RegistrationV2:
-		return fmt.Errorf("%w: RegistrationV2 does not use an Until field", ErrInvalidType)
+	case *SchemaV2:
+		return fmt.Errorf("%w: SchemaV2 does not use an Until field", ErrInvalidType)
 	default:
 		return ErrUknownType
 	}
@@ -309,10 +309,10 @@ type untilOption struct {
 
 func (u untilOption) Validate(i any) error {
 	switch r := i.(type) {
-	case *RegistrationV1:
+	case *SchemaV1:
 		return r.CheckUntil(u.now, u.jitter, u.max)
-	case *RegistrationV2:
-		return fmt.Errorf("%w: RegistrationV2 does not use an Until field", ErrInvalidType)
+	case *SchemaV2:
+		return fmt.Errorf("%w: SchemaV2 does not use an Until field", ErrInvalidType)
 	default:
 		return ErrUknownType
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package webhook
+package stream
 
 import (
 	"testing"
@@ -29,22 +29,22 @@ func TestErrorOption(t *testing.T) {
 	run_tests(t, []optionTest{
 		{
 			description: "success",
-			in:          &RegistrationV1{},
+			in:          &SchemaV1{},
 			str:         "foo",
 		},
 		{
-			description: "simple error - RegistrationV1",
+			description: "simple error - SchemaV1",
 			opt:         Error(ErrInvalidInput),
 			str:         "Error('invalid input')",
 			expectedErr: ErrInvalidInput,
-			in:          &RegistrationV1{},
+			in:          &SchemaV1{},
 		},
 		{
-			description: "simple error - RegistrationV2",
+			description: "simple error - SchemaV2",
 			opt:         Error(ErrInvalidInput),
 			str:         "Error('invalid input')",
 			expectedErr: ErrInvalidInput,
-			in:          &RegistrationV2{},
+			in:          &SchemaV2{},
 		},
 		{
 			description: "simple nil error",
@@ -59,7 +59,7 @@ func TestAlwaysOption(t *testing.T) {
 		{
 			description: "success",
 			opt:         AlwaysValid(),
-			in:          &RegistrationV1{},
+			in:          &SchemaV1{},
 			str:         "alwaysValidOption",
 		},
 	})
@@ -69,23 +69,23 @@ func TestAtLeastOneEventOption(t *testing.T) {
 		{
 			description: "there is an event - V1",
 			opt:         AtLeastOneEvent(),
-			in:          &RegistrationV1{Events: []string{"foo"}},
+			in:          &SchemaV1{Events: []string{"foo"}},
 			str:         "AtLeastOneEvent()",
 		}, {
 			description: "multiple events - V1",
 			opt:         AtLeastOneEvent(),
-			in:          &RegistrationV1{Events: []string{"foo", "bar"}},
+			in:          &SchemaV1{Events: []string{"foo", "bar"}},
 			str:         "AtLeastOneEvent()",
 		}, {
 			description: "there are no events - V1",
 			opt:         AtLeastOneEvent(),
-			in:          &RegistrationV1{},
+			in:          &SchemaV1{},
 			expectedErr: ErrInvalidInput,
 		},
 		{
-			description: "invalid type - RegistrationV2",
+			description: "invalid type - SchemaV2",
 			opt:         AtLeastOneEvent(),
-			in:          &RegistrationV2{},
+			in:          &SchemaV2{},
 			expectedErr: ErrInvalidType,
 		},
 		{
@@ -101,35 +101,35 @@ func TestEventRegexMustCompile(t *testing.T) {
 		{
 			description: "the regex compiles - V1",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV1{Events: []string{"event.*"}},
+			in:          &SchemaV1{Events: []string{"event.*"}},
 			str:         "EventRegexMustCompile()",
 		}, {
 			description: "multiple events",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV1{Events: []string{"magic-thing", "event.*"}},
+			in:          &SchemaV1{Events: []string{"magic-thing", "event.*"}},
 			str:         "EventRegexMustCompile()",
 		}, {
 			description: "failure - V1",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV1{Events: []string{"("}},
+			in:          &SchemaV1{Events: []string{"("}},
 			expectedErr: ErrInvalidInput,
 		},
 		{
 			description: "the regex compiles - V2",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV2{Matcher: []FieldRegex{{Field: "canonical_name", Regex: "webpa"}}},
+			in:          &SchemaV2{Matcher: []FieldRegex{{Field: "canonical_name", Regex: "webpa"}}},
 			str:         "EventRegexMustCompile()",
 		},
 		{
 			description: "multiple matchers - V2",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV2{Matcher: []FieldRegex{{Field: "canonical_name", Regex: "webpa"}, {Field: "address", Regex: "www.example.com"}}},
+			in:          &SchemaV2{Matcher: []FieldRegex{{Field: "canonical_name", Regex: "webpa"}, {Field: "address", Regex: "www.example.com"}}},
 			str:         "EventRegexMustCompile()",
 		},
 		{
 			description: "failure - V2",
 			opt:         EventRegexMustCompile(),
-			in:          &RegistrationV2{Matcher: []FieldRegex{{Regex: "("}}},
+			in:          &SchemaV2{Matcher: []FieldRegex{{Regex: "("}}},
 			expectedErr: ErrInvalidInput,
 		},
 		{
@@ -145,23 +145,23 @@ func TestDeviceIDRegexMustCompile(t *testing.T) {
 		{
 			description: "the regex compiles - v1",
 			opt:         DeviceIDRegexMustCompile(),
-			in:          &RegistrationV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"device.*"}}},
+			in:          &SchemaV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"device.*"}}},
 			str:         "DeviceIDRegexMustCompile()",
 		}, {
 			description: "multiple device ids - v1",
 			opt:         DeviceIDRegexMustCompile(),
-			in:          &RegistrationV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"device.*", "magic-thing"}}},
+			in:          &SchemaV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"device.*", "magic-thing"}}},
 			str:         "DeviceIDRegexMustCompile()",
 		}, {
 			description: "failure - v1",
 			opt:         DeviceIDRegexMustCompile(),
-			in:          &RegistrationV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"("}}},
+			in:          &SchemaV1{Matcher: MetadataMatcherConfig{DeviceID: []string{"("}}},
 			expectedErr: ErrInvalidInput,
 		},
 		{
 			description: "invalid type - v2",
 			opt:         DeviceIDRegexMustCompile(),
-			in:          &RegistrationV2{},
+			in:          &SchemaV2{},
 			expectedErr: ErrInvalidType,
 		},
 		{
@@ -172,81 +172,81 @@ func TestDeviceIDRegexMustCompile(t *testing.T) {
 	})
 }
 
-func TestValidateRegistrationDuration(t *testing.T) {
+func TestValidateDuration(t *testing.T) {
 	now := func() time.Time {
 		return time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 	}
 	run_tests(t, []optionTest{
 		{
 			description: "success with time in bounds - V1",
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
-			in:          &RegistrationV1{Duration: CustomDuration(4 * time.Minute)},
-			str:         "ValidateRegistrationDuration(5m0s)",
+			opt:         ValidateDuration(5 * time.Minute),
+			in:          &SchemaV1{Duration: CustomDuration(4 * time.Minute)},
+			str:         "ValidateDuration(5m0s)",
 		}, {
 			description: "success with time in bounds, exactly - V1",
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
-			in:          &RegistrationV1{Duration: CustomDuration(5 * time.Minute)},
+			opt:         ValidateDuration(5 * time.Minute),
+			in:          &SchemaV1{Duration: CustomDuration(5 * time.Minute)},
 		}, {
 			description: "failure with time out of bounds - V1",
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
-			in:          &RegistrationV1{Duration: CustomDuration(6 * time.Minute)},
+			opt:         ValidateDuration(5 * time.Minute),
+			in:          &SchemaV1{Duration: CustomDuration(6 * time.Minute)},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "success with max ttl ignored - V1",
-			opt:         ValidateRegistrationDuration(-5 * time.Minute),
-			in:          &RegistrationV1{Duration: CustomDuration(1 * time.Minute)},
+			opt:         ValidateDuration(-5 * time.Minute),
+			in:          &SchemaV1{Duration: CustomDuration(1 * time.Minute)},
 		}, {
 			description: "success with max ttl ignored, 0 duration - V1",
-			opt:         ValidateRegistrationDuration(0),
-			in:          &RegistrationV1{Duration: CustomDuration(1 * time.Minute)},
+			opt:         ValidateDuration(0),
+			in:          &SchemaV1{Duration: CustomDuration(1 * time.Minute)},
 		}, {
 			description: "success with until in bounds - V1",
-			opts:        []Option{ProvideTimeNowFunc(now), ValidateRegistrationDuration(5 * time.Minute)},
-			in:          &RegistrationV1{Until: time.Date(2021, 1, 1, 0, 4, 0, 0, time.UTC)},
+			opts:        []Option{ProvideTimeNowFunc(now), ValidateDuration(5 * time.Minute)},
+			in:          &SchemaV1{Until: time.Date(2021, 1, 1, 0, 4, 0, 0, time.UTC)},
 		}, {
 			description: "failure due to until being before now - V1",
-			opts:        []Option{ValidateRegistrationDuration(5 * time.Minute), ProvideTimeNowFunc(now)},
-			in: &RegistrationV1{
+			opts:        []Option{ValidateDuration(5 * time.Minute), ProvideTimeNowFunc(now)},
+			in: &SchemaV1{
 				Until: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "success with until exactly in bounds - V1",
-			opts:        []Option{ProvideTimeNowFunc(now), ValidateRegistrationDuration(5 * time.Minute)},
-			in:          &RegistrationV1{Until: time.Date(2021, 1, 1, 0, 5, 0, 0, time.UTC)},
+			opts:        []Option{ProvideTimeNowFunc(now), ValidateDuration(5 * time.Minute)},
+			in:          &SchemaV1{Until: time.Date(2021, 1, 1, 0, 5, 0, 0, time.UTC)},
 		}, {
 			description: "failure due to the options being out of order - V1",
-			opts:        []Option{ValidateRegistrationDuration(5 * time.Minute), ProvideTimeNowFunc(now)},
-			in:          &RegistrationV1{Until: time.Date(2021, 1, 1, 0, 5, 0, 0, time.UTC)},
+			opts:        []Option{ValidateDuration(5 * time.Minute), ProvideTimeNowFunc(now)},
+			in:          &SchemaV1{Until: time.Date(2021, 1, 1, 0, 5, 0, 0, time.UTC)},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "failure with until out of bounds - V1",
-			opts:        []Option{ProvideTimeNowFunc(now), ValidateRegistrationDuration(5 * time.Minute)},
-			in:          &RegistrationV1{Until: time.Date(2021, 1, 1, 0, 6, 0, 0, time.UTC)},
+			opts:        []Option{ProvideTimeNowFunc(now), ValidateDuration(5 * time.Minute)},
+			in:          &SchemaV1{Until: time.Date(2021, 1, 1, 0, 6, 0, 0, time.UTC)},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "success with until just needing to be present - V1",
-			opts:        []Option{ProvideTimeNowFunc(now), ValidateRegistrationDuration(0)},
-			in:          &RegistrationV1{Until: time.Date(2021, 1, 1, 0, 6, 0, 0, time.UTC)},
+			opts:        []Option{ProvideTimeNowFunc(now), ValidateDuration(0)},
+			in:          &SchemaV1{Until: time.Date(2021, 1, 1, 0, 6, 0, 0, time.UTC)},
 		}, {
 			description: "failure, both expirations set - V1",
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
-			in:          &RegistrationV1{Duration: CustomDuration(1 * time.Minute), Until: time.Date(2021, 1, 1, 0, 4, 0, 0, time.UTC)},
+			opt:         ValidateDuration(5 * time.Minute),
+			in:          &SchemaV1{Duration: CustomDuration(1 * time.Minute), Until: time.Date(2021, 1, 1, 0, 4, 0, 0, time.UTC)},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "failure, no expiration set - V1",
-			in:          &RegistrationV1{},
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
+			in:          &SchemaV1{},
+			opt:         ValidateDuration(5 * time.Minute),
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "failure, exipred - V2",
-			in:          &RegistrationV2{Expires: now()},
-			opt:         ValidateRegistrationDuration(0),
+			in:          &SchemaV2{Expires: now()},
+			opt:         ValidateDuration(0),
 			expectedErr: ErrInvalidInput,
 		},
 		{
 			description: "default case - unknown",
-			opt:         ValidateRegistrationDuration(5 * time.Minute),
+			opt:         ValidateDuration(5 * time.Minute),
 			expectedErr: ErrUknownType,
 		},
 	})
@@ -283,22 +283,22 @@ func TestProvideFailureURLValidator(t *testing.T) {
 		}, {
 			description: "success, with checker - V1",
 			opt:         ProvideFailureURLValidator(checker),
-			in:          &RegistrationV1{FailureURL: "https://example.com"},
+			in:          &SchemaV1{FailureURL: "https://example.com"},
 			str:         "ProvideFailureURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "failure, with checker - V1",
 			opt:         ProvideFailureURLValidator(checker),
-			in:          &RegistrationV1{FailureURL: "http://example.com"},
+			in:          &SchemaV1{FailureURL: "http://example.com"},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "success, with checker - V2",
 			opt:         ProvideFailureURLValidator(checker),
-			in:          &RegistrationV2{FailureURL: "https://example.com"},
+			in:          &SchemaV2{FailureURL: "https://example.com"},
 			str:         "ProvideFailureURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "failure, with checker - V2",
 			opt:         ProvideFailureURLValidator(checker),
-			in:          &RegistrationV2{FailureURL: "http://example.com"},
+			in:          &SchemaV2{FailureURL: "http://example.com"},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "default case - unknown",
@@ -321,22 +321,22 @@ func TestProvideReceiverURLValidator(t *testing.T) {
 		}, {
 			description: "success, with checker - V1",
 			opt:         ProvideReceiverURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{ReceiverURL: "https://example.com"}},
+			in:          &SchemaV1{Config: DeliveryConfig{ReceiverURL: "https://example.com"}},
 			str:         "ProvideReceiverURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "failure, with checker - V1",
 			opt:         ProvideReceiverURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{ReceiverURL: "http://example.com"}},
+			in:          &SchemaV1{Config: DeliveryConfig{ReceiverURL: "http://example.com"}},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "success, with checker - V2",
 			opt:         ProvideReceiverURLValidator(checker),
-			in:          &RegistrationV2{Webhooks: []Webhook{{ReceiverURLs: []string{"https://example.com", "https://example2.com"}}}},
+			in:          &SchemaV2{Webhooks: []Webhook{{ReceiverURLs: []string{"https://example.com", "https://example2.com"}}}},
 			str:         "ProvideReceiverURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "failure, with checker - V2",
 			opt:         ProvideReceiverURLValidator(checker),
-			in:          &RegistrationV2{Webhooks: []Webhook{{ReceiverURLs: []string{"https://example.com", "http://example2.com"}}}},
+			in:          &SchemaV2{Webhooks: []Webhook{{ReceiverURLs: []string{"https://example.com", "http://example2.com"}}}},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "default case - unknown",
@@ -359,27 +359,27 @@ func TestProvideAlternativeURLValidator(t *testing.T) {
 		}, {
 			description: "success, with checker",
 			opt:         ProvideAlternativeURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com"}}},
+			in:          &SchemaV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com"}}},
 			str:         "ProvideAlternativeURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "success, with checker and multiple urls",
 			opt:         ProvideAlternativeURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com", "https://example.org"}}},
+			in:          &SchemaV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com", "https://example.org"}}},
 			str:         "ProvideAlternativeURLValidator(urlegit.Checker{ OnlyAllowSchemes('https') })",
 		}, {
 			description: "failure, with checker",
 			opt:         ProvideAlternativeURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{AlternativeURLs: []string{"http://example.com"}}},
+			in:          &SchemaV1{Config: DeliveryConfig{AlternativeURLs: []string{"http://example.com"}}},
 			expectedErr: ErrInvalidInput,
 		}, {
 			description: "failure, with checker with multiple urls",
 			opt:         ProvideAlternativeURLValidator(checker),
-			in:          &RegistrationV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com", "http://example.com"}}},
+			in:          &SchemaV1{Config: DeliveryConfig{AlternativeURLs: []string{"https://example.com", "http://example.com"}}},
 			expectedErr: ErrInvalidInput,
 		}, {
-			description: "failure - RegistrationV2",
+			description: "failure - SchemaV2",
 			opt:         ProvideAlternativeURLValidator(checker),
-			in:          &RegistrationV2{},
+			in:          &SchemaV2{},
 			expectedErr: ErrInvalidType,
 		}, {
 			description: "default case - unknown",
@@ -393,13 +393,13 @@ func TestNoUntil(t *testing.T) {
 	run_tests(t, []optionTest{
 		{
 			description: "success, no until set",
-			in:          &RegistrationV1{},
+			in:          &SchemaV1{},
 			opt:         NoUntil(),
 			str:         "NoUntil()",
 		}, {
 			description: "detect until set",
 			opt:         NoUntil(),
-			in: &RegistrationV1{
+			in: &SchemaV1{
 				Until: time.Now(),
 			},
 			expectedErr: ErrInvalidInput,
@@ -407,7 +407,7 @@ func TestNoUntil(t *testing.T) {
 		{
 			description: "failure - V2",
 			opt:         NoUntil(),
-			in:          &RegistrationV2{},
+			in:          &SchemaV2{},
 			expectedErr: ErrInvalidType,
 		},
 		{
@@ -422,7 +422,7 @@ func TestUntilOption(t *testing.T) {
 	run_tests(t, []optionTest{
 		{
 			description: "success, until",
-			in: &RegistrationV1{
+			in: &SchemaV1{
 				Until: mockNow(),
 			},
 			opt: Until(time.Now, time.Duration(1*time.Minute), time.Duration(5*time.Minute)),
@@ -437,9 +437,9 @@ func run_tests(t *testing.T, tests []optionTest) {
 			var err error
 			opts := append(tc.opts, tc.opt)
 			switch r := tc.in.(type) {
-			case *RegistrationV1:
+			case *SchemaV1:
 				err = opts.Validate(r)
-			case *RegistrationV2:
+			case *SchemaV2:
 				err = opts.Validate(r)
 			default:
 				err = opts.Validate(nil)

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,4 +1,4 @@
 // SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package webhook
+package stream


### PR DESCRIPTION
Since multi sink support has been added to webhook-schema (i.e.: webhook-schema supports more than just webhooks now), webhook-schema's old naming scheme has become a tripping hazard. This commit/pr proposes a new naming scheme that's sink agnostic and more aligned with webhook-schema's new functionality:

- `webhooks.go` have been renamed to  `stream.go`
- `RegistrationV1` and `RegistrationV2` have been renamed to `SchemaV1` and `SchemaV2`
   - a better name for what it is